### PR TITLE
Merge with an empty array wipes the original array

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ This merger will check both arrays and only do anything if both of them has an o
 It can also be used with the `deep` configuration to do this recursively.
 
 ## Releases
+### 3.0.1
+Fixed a bug in *updatingByIdArrayMerger* where a merge with an empty array would wipe the content of the current array.
+
 ### 3.0.0
 Updated to *[seamless-immutable](https://github.com/rtfeldman/seamless-immutable)* 3.0.0 and bumped the major version to be in sync.
 

--- a/seamless-immutable-mergers.js
+++ b/seamless-immutable-mergers.js
@@ -27,7 +27,8 @@
 
   function updatingByIdArrayMerger(current, other, config) {
     if (!(current instanceof Array) || !(other instanceof Array)) return;
-    if (current.length === 0 || other.length === 0) return;
+    if (current.length === 0) return;
+    if (other.length === 0) return current;
 
     var identifier = config.mergerObjectIdentifier;
     if (current[0] === null || !(typeof current[0] === "object") || !current[0][identifier]) return;

--- a/test/UpdatingByIdArrayMerger.spec.js
+++ b/test/UpdatingByIdArrayMerger.spec.js
@@ -184,4 +184,65 @@ describe("UpdatingByIdArrayMerger", function() {
     assert.equal(items[1].status, "ok");
     assert.equal(items[1].content, "media");
   });
+
+  it("doesn't empty an array when the push contains an empty array", function() {
+    var current = immutable({
+      array: [
+        {
+          id: 10,
+          status: "ok",
+          content: "text",
+          items: [
+            {
+              id: 100,
+              status: "ok",
+              content: "text"
+            }
+          ]
+        }
+      ]
+    });
+
+    var update = {
+      array: []
+    };
+
+    var result = current.merge(update, config);
+    assert.equal(result.array.length, 1);
+  });
+
+  it("doesn't deeply empty an array when the push contains an empty array", function() {
+    var current = immutable({
+      array: [
+        {
+          id: 10,
+          status: "ok",
+          content: "text",
+          items: [
+            {
+              id: 100,
+              status: "ok",
+              content: "text"
+            }
+          ]
+        }
+      ]
+    });
+
+    var update = {
+      array: [
+        {
+          id: 10,
+          items: []
+        }
+      ]
+    };
+
+    var result = current.merge(update, config);
+    assert.equal(result.array.length, 1);
+
+    var resultObject = result.array[0];
+    var items = resultObject.items;
+    assert.equal(items.length, 1);
+  });
 });


### PR DESCRIPTION
If the update contains an empty array then _updatingByIdArrayMerger_ will wipe the original array. Instead it should leave the array as is. Also added tests for it.
